### PR TITLE
Print "Missing input file." when gen {json|ts} is executed without any files

### DIFF
--- a/cli/pb/cmds/gen/cmds/json.ts
+++ b/cli/pb/cmds/gen/cmds/json.ts
@@ -30,6 +30,9 @@ export default new Command()
     const roots = [...protoPaths, Deno.cwd(), vendorPath];
     const loader = createLoader({ roots });
     const schema = await build({ loader, files: protoFiles });
+
+    if (Object.keys(schema.files).length == 0) return;
+
     console.log(gen(schema, {
       includeParseResult: options.ast,
       space: options.space,

--- a/cli/pb/cmds/gen/cmds/json.ts
+++ b/cli/pb/cmds/gen/cmds/json.ts
@@ -31,8 +31,8 @@ export default new Command()
     const loader = createLoader({ roots });
     const schema = await build({ loader, files: protoFiles });
     if (Object.keys(schema.files).length == 0) {
-      console.log("Missing input file.");
-      return;
+      console.error("Missing input file.");
+      Deno.exit(1);
     }
     console.log(gen(schema, {
       includeParseResult: options.ast,

--- a/cli/pb/cmds/gen/cmds/json.ts
+++ b/cli/pb/cmds/gen/cmds/json.ts
@@ -30,9 +30,10 @@ export default new Command()
     const roots = [...protoPaths, Deno.cwd(), vendorPath];
     const loader = createLoader({ roots });
     const schema = await build({ loader, files: protoFiles });
-
-    if (Object.keys(schema.files).length == 0) return;
-
+    if (Object.keys(schema.files).length == 0) {
+      console.log("Missing input file.");
+      return;
+    }
     console.log(gen(schema, {
       includeParseResult: options.ast,
       space: options.space,

--- a/cli/pb/cmds/gen/cmds/ts.ts
+++ b/cli/pb/cmds/gen/cmds/ts.ts
@@ -33,12 +33,10 @@ export default new Command()
     const roots = [...protoPaths, Deno.cwd(), vendorPath];
     const loader = createLoader({ roots });
     const schema = await build({ loader, files: protoFiles });
-
     if (Object.keys(schema.files).length == 0) {
       console.log("Missing input file.");
       return;
     }
-
     await save(
       options.outDir,
       gen(schema, {

--- a/cli/pb/cmds/gen/cmds/ts.ts
+++ b/cli/pb/cmds/gen/cmds/ts.ts
@@ -33,6 +33,9 @@ export default new Command()
     const roots = [...protoPaths, Deno.cwd(), vendorPath];
     const loader = createLoader({ roots });
     const schema = await build({ loader, files: protoFiles });
+
+    if (Object.keys(schema.files).length == 0) return;
+
     await save(
       options.outDir,
       gen(schema, {

--- a/cli/pb/cmds/gen/cmds/ts.ts
+++ b/cli/pb/cmds/gen/cmds/ts.ts
@@ -34,8 +34,8 @@ export default new Command()
     const loader = createLoader({ roots });
     const schema = await build({ loader, files: protoFiles });
     if (Object.keys(schema.files).length == 0) {
-      console.log("Missing input file.");
-      return;
+      console.error("Missing input file.");
+      Deno.exit(1);
     }
     await save(
       options.outDir,

--- a/cli/pb/cmds/gen/cmds/ts.ts
+++ b/cli/pb/cmds/gen/cmds/ts.ts
@@ -34,7 +34,10 @@ export default new Command()
     const loader = createLoader({ roots });
     const schema = await build({ loader, files: protoFiles });
 
-    if (Object.keys(schema.files).length == 0) return;
+    if (Object.keys(schema.files).length == 0) {
+      console.log("Missing input file.");
+      return;
+    }
 
     await save(
       options.outDir,


### PR DESCRIPTION
## As-is

generate out when there are no proto files in running gen command

![image](https://user-images.githubusercontent.com/15096588/132969220-072237d0-9337-4afa-877a-234bb3cf1ada.png)

## To-be

~skipping generation~ prints error message same as protoc when there are no proto files in running gen command

![image](https://user-images.githubusercontent.com/15096588/132969236-f0bb151f-b6b5-4adf-b641-354c0249f094.png)
