### PR TITLE
맥/윈도우 파일 시스템이 case-insensitive여서 생기는 디렉토리명 중복 문제 수정

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -64,7 +64,10 @@ export function getFilePath(
 ): string {
   return join(
     messages.outDir,
-    typePath.replace(/^\./, "").replaceAll(".", "/") + ext,
+    typePath
+      .replace(/^\./, "")
+      .replaceAll(".", "/")
+      .replaceAll(/\b([A-Z][^/]*)\//g, "($1)/") + ext,
   );
 }
 


### PR DESCRIPTION
nested message가 있어 디렉토리가 만들어지는 경우에는 소괄호로 감싸서 디렉토리를 생성해 주도록 하였습니다.  
하지만 메세지가 모두 대문자로 시작하는 것을 전제로 하였기 때문에, 추후 소문자 message에서도 대응이 되도록 수정해야 합니다.