### PR TITLE
Add createValueCode function in message codegen

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -215,6 +215,7 @@ function* genMessage({
   };
   const typeDefCode = getMessageTypeDefCode(getCodeConfig);
   const getDefaultValueCode = getGetDefaultValueCode(getCodeConfig);
+  const createValueCode = getCreateValueCode(getCodeConfig);
   const encodeJsonCode = getEncodeJsonCode(getCodeConfig);
   const decodeJsonCode = getDecodeJsonCode(getCodeConfig);
   const encodeBinaryCode = getEncodeBinaryCode(getCodeConfig);
@@ -227,6 +228,7 @@ function* genMessage({
         importCode ? importCode + "\n" : "",
         typeDefCode,
         "\n" + getDefaultValueCode,
+        "\n" + createValueCode,
         "\n" + encodeJsonCode,
         "\n" + decodeJsonCode,
         "\n" + encodeBinaryCode,
@@ -333,6 +335,18 @@ const getGetDefaultValueCode: GetCodeFn = ({ typePath, message }) => {
     "  };\n",
     "}\n",
   ].join("");
+};
+
+const getCreateValueCode: GetCodeFn = ({ typePath }) => {
+  return [
+    `export function createValue(partialValue: Partial<$${typePath}>): $${typePath} {`,
+    `  return {`,
+    `    ...getDefaultValue(),`,
+    `    ...partialValue`,
+    `  };`,
+    `}`,
+    "",
+  ].join("\n");
 };
 
 const getEncodeJsonCode: GetCodeFn = ({

--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -344,7 +344,7 @@ const getCreateValueCode: GetCodeFn = ({ typePath }) => {
     `export function createValue(partialValue: Partial<$${typePath}>): $${typePath} {`,
     `  return {`,
     `    ...getDefaultValue(),`,
-    `    ...partialValue`,
+    `    ...partialValue,`,
     `  };`,
     `}`,
     "",

--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -144,6 +144,8 @@ interface OneofField {
 const reservedNames = [
   "Type",
   "Uint8Array",
+  "getDefaultValue",
+  "createValue",
   "encodeBinary",
   "decodeBinary",
   "encodeJson",


### PR DESCRIPTION
테스트 코드나 storybook 코드를 대체할 때 각 메세지 타입들의 객체를 많이 만들어야 하는데, 이때마다 `...getDefaultValue()` 를 사용하여 기본값을 정해주기가 매우 번거로워 `createValue` 함수를 만들어 대체하도록 했습니다. 