### PR TITLE
Change Content-Length header name to be case-sensitive

### DIFF
--- a/language-server/base-protocol.ts
+++ b/language-server/base-protocol.ts
@@ -37,7 +37,9 @@ export async function writeBaseProtocolMessage(
   headers: Headers = new Headers(),
 ): Promise<void> {
   const bufWriter = new BufWriter(writer);
-  headers.set("Content-Length", String(body.length));
+  await bufWriter.write(
+    textEncoder.encode(`Content-Length: ${body.length}\r\n`),
+  );
   await bufWriter.write(textEncoder.encode(
     Array.from(headers.entries()).map(
       ([key, value]) => `${key}: ${value}\r\n`,


### PR DESCRIPTION
Web API Headers는 map key의 케이스를 누르는데, vscode-languageserver-node가 case-sensitive한 동작으로 Content-Length를 찾아 에러가 발생합니다.

related to https://github.com/microsoft/vscode-languageserver-node/issues/897