### PR TITLE
refactor(lsp): Add lsp type definition and apply on request handlers in `server.ts`

### DIFF
--- a/core/schema/builder.ts
+++ b/core/schema/builder.ts
@@ -417,7 +417,7 @@ function getDescription(commentGroups: ast.CommentGroup[]): string {
   return parseDocComment(docComment?.text ?? "");
 }
 
-type ResolveTypePathFn = (
+export type ResolveTypePathFn = (
   type: string,
   scope: `.${string}`,
 ) => string | undefined;

--- a/language-server/json-rpc.ts
+++ b/language-server/json-rpc.ts
@@ -40,7 +40,7 @@ export interface NotificationHandlers {
   [methodName: string]: (params: any) => void;
 }
 export interface RequestHandlers {
-  [methodName: string]: (params: any) => any | Promise<any>;
+  [methodName: string]: (params: any) => any;
 }
 export function createJsonRpcConnection(
   config: CreateJsonRpcConnectionConfig,

--- a/language-server/json-rpc.ts
+++ b/language-server/json-rpc.ts
@@ -40,7 +40,7 @@ export interface NotificationHandlers {
   [methodName: string]: (params: any) => void;
 }
 export interface RequestHandlers {
-  [methodName: string]: (params: any) => Promise<any>;
+  [methodName: string]: (params: any) => any | Promise<any>;
 }
 export function createJsonRpcConnection(
   config: CreateJsonRpcConnectionConfig,
@@ -127,9 +127,9 @@ export function createJsonRpcConnection(
             });
             continue;
           }
-          config.requestHandlers[message.method](
+          Promise.resolve(config.requestHandlers[message.method](
             message.params,
-          ).then((result) =>
+          )).then((result) =>
             writeMessage({
               jsonrpc: "2.0",
               id: message.id,

--- a/language-server/lsp.ts
+++ b/language-server/lsp.ts
@@ -76,6 +76,81 @@ export interface ReferenceContext {
 }
 
 /**
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#hoverParams
+ */
+export interface HoverParams
+  extends TextDocumentPositionParams, WorkDoneProgressParams {
+}
+
+export type HoverResponse = Hover | null;
+/**
+ * The result of a hover request.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#hover
+ */
+export interface Hover {
+  /**
+   * The hover's content
+   * MarkedString is deprecated. Use MarkupContent instead.
+   */
+  contents: MarkupContent;
+
+  /**
+   * An optional range is a range inside a text document
+   * that is used to visualize a hover, e.g. by changing the background color.
+   */
+  range?: Range;
+}
+
+/**
+ * A `MarkupContent` literal represents a string value which content is
+ * interpreted base on its kind flag. Currently the protocol supports
+ * `plaintext` and `markdown` as markup kinds.
+ *
+ * If the kind is `markdown` then the value can contain fenced code blocks like
+ * in GitHub issues.
+ *
+ * Here is an example how such a string can be constructed using
+ * JavaScript / TypeScript:
+ * ```typescript
+ * let markdown: MarkdownContent = {
+ * 	kind: MarkupKind.Markdown,
+ * 	value: [
+ * 		'# Header',
+ * 		'Some text',
+ * 		'```typescript',
+ * 		'someCode();',
+ * 		'```'
+ * 	].join('\n')
+ * };
+ * ```
+ *
+ * *Please Note* that clients might sanitize the return markdown. A client could
+ * decide to remove HTML from the markdown to avoid script execution.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#markupContentInnerDefinition
+ */
+export interface MarkupContent {
+  /**
+   * The type of the Markup
+   */
+  kind: MarkupKind;
+
+  /**
+   * The content itself
+   */
+  value: string;
+}
+
+/**
+ * Describes the content type that a client supports in various
+ * result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+ *
+ * Please note that `MarkupKinds` must not start with a `$`. This kinds
+ * are reserved for internal usage.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#markupContent
+ */
+export type MarkupKind = "plaintext" | "markdown";
+
+/**
  * A parameter literal used to pass a partial result token.
  * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#partialResultParams
  */

--- a/language-server/lsp.ts
+++ b/language-server/lsp.ts
@@ -1,0 +1,255 @@
+interface WorkspaceFolder {
+  uri: DocumentUri;
+  name: string;
+}
+
+export interface InitializeParams {
+  workspaceFolders?: WorkspaceFolder[] | null;
+}
+export interface InitializeResult {
+  capabilities: ServerCapabilities;
+  serverInfo?: {
+    name: string;
+    version?: string;
+  };
+}
+
+export enum TextDocumentSyncKind {
+  None = 0,
+  Full = 1,
+  Incremental = 2,
+}
+interface CompletionOptions {
+  resolveProvider?: boolean;
+  completionItem?: {
+    labelDetailsSupport?: boolean;
+  };
+}
+interface ServerCapabilities {
+  textDocumentSync?: TextDocumentSyncKind;
+  completionProvider?: CompletionOptions;
+  hoverProvider?: boolean;
+  declarationProvider?: boolean; // @TODO: Add Support for DeclarationRegistrationOptions
+  definitionProvider?: boolean; // @TODO: Add Support for DefinitionOptions
+  typeDefinitionProvider?: boolean; // @TODO: Add Support for TypeDefinitionRegistrationOptions
+  implementationProvider?: boolean; // @TODO: Add Support for ImplementationRegistrationOptions
+  referencesProvider?: boolean;
+  workspace?: {
+    workspaceFolders?: {
+      supported?: boolean;
+    };
+  };
+}
+
+/**
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#definitionParams
+ */
+export interface DefinitionParams
+  extends
+    TextDocumentPositionParams,
+    WorkDoneProgressParams,
+    PartialResultParams {}
+
+export type DefinitionResponse = Location | Location[] | LocationLink[] | null;
+
+/**
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#referenceParams
+ */
+export interface ReferenceParams
+  extends
+    TextDocumentPositionParams,
+    WorkDoneProgressParams,
+    PartialResultParams {
+  context: ReferenceContext;
+}
+
+export type ReferenceResponse = Location[] | null;
+
+/**
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#referenceContext
+ */
+export interface ReferenceContext {
+  /**
+   * Include the declaration of the current symbol.
+   */
+  includeDeclaration: boolean;
+}
+
+/**
+ * A parameter literal used to pass a partial result token.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#partialResultParams
+ */
+export interface PartialResultParams {
+  /**
+   * An optional token that a server can use to report partial results (e.g.
+   * streaming) to the client.
+   */
+  partialResultToken?: ProgressToken;
+}
+
+/**
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#workDoneProgressParams
+ */
+interface WorkDoneProgressParams {
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
+  workDoneToken?: ProgressToken;
+}
+
+/**
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocumentPositionParams
+ */
+interface TextDocumentPositionParams {
+  textDocument: TextDocumentIdentifier;
+  position: Position;
+}
+
+/**
+ * Text documents are identified using a URI. On the protocol level, URIs are passed as strings. The corresponding JSON structure looks like this:
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocumentIdentifier
+ */
+interface TextDocumentIdentifier {
+  /**
+   * The text document's URI.
+   */
+  uri: DocumentUri;
+}
+
+/**
+ * Options to dynamically register for requests for a set of text documents.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocumentRegistrationOptions
+ */
+interface TextDocumentRegistrationOptions {
+  documentSelector: DocumentSelector | null;
+}
+
+/**
+ * A document selector is the combination of one or more document filters.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#documentSelector
+ */
+type DocumentSelector = DocumentFilter[];
+
+/**
+ * A document filter denotes a document through properties like language, scheme or pattern. An example is a filter that applies to TypeScript files on disk. Another example is a filter the applies to JSON files with name package.json
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#documentFilter
+ */
+interface DocumentFilter {
+  language?: string;
+  scheme?: string;
+  pattern?: string;
+}
+
+/**
+ * Represents a location inside a resource, such as a line inside a text file.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#location
+ */
+export interface Location {
+  uri: DocumentUri;
+  range: Range;
+}
+
+/**
+ * Represents a link between a source and a target location.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#locationLink
+ */
+interface LocationLink {
+  /**
+   * Span of the origin of this link.
+   *
+   * Used as the underlined span for mouse interaction. Defaults to the word
+   * range at the mouse position.
+   */
+  originSelectionRange?: Range;
+
+  /**
+   * The target resource identifier of this link.
+   */
+  targetUri: DocumentUri;
+
+  /**
+   * The full target range of this link. If the target for example is a symbol
+   * then target range is the range enclosing this symbol not including
+   * leading/trailing whitespace but everything else like comments. This
+   * information is typically used to highlight the range in the editor.
+   */
+  targetRange: Range;
+
+  /**
+   * The range that should be selected and revealed when this link is being
+   * followed, e.g the name of a function. Must be contained by the the
+   * `targetRange`. See also `DocumentSymbol#range`
+   */
+  targetSelectionRange: Range;
+}
+
+/**
+ * A range in a text document expressed as (zero-based) start and end positions. A range is comparable to a selection in an editor. Therefore the end position is exclusive. If you want to specify a range that contains a line including the line ending character(s) then use an end position denoting the start of the next line.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#range
+ */
+interface Range {
+  /**
+   * The range's start position.
+   */
+  start: Position;
+
+  /**
+   * The range's end position.
+   */
+  end: Position;
+}
+
+/**
+ * Position in a text document expressed as zero-based line and zero-based character offset. A position is between two characters like an ‘insert’ cursor in an editor. Special values like for example -1 to denote the end of a line are not supported.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#position
+ */
+export interface Position {
+  /**
+   * Line position in a document (zero-based).
+   */
+  line: uinteger;
+
+  /**
+   * Character offset on a line in a document (zero-based). Assuming that
+   * the line is represented as a string, the `character` value represents
+   * the gap between the `character` and `character + 1`.
+   *
+   * If the character value is greater than the line length it defaults back
+   * to the line length.
+   */
+  character: uinteger;
+}
+
+/**
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#progress
+ */
+type ProgressToken = integer | string;
+
+/**
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#progress
+ */
+interface ProgressParams<T> {
+  /**
+   * The progress token provided by the client or server.
+   */
+  token: ProgressToken;
+
+  /**
+   * The progress data.
+   */
+  value: T;
+}
+
+/**
+ * Defines an integer number in the range of -2^31 to 2^31 - 1.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#integer
+ */
+export type integer = number;
+
+/**
+ * Defines an unsigned integer number in the range of 0 to 2^31 - 1.
+ * @docs https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#uinteger
+ */
+export type uinteger = number;
+
+type DocumentUri = string;

--- a/language-server/server.ts
+++ b/language-server/server.ts
@@ -33,7 +33,7 @@ export function run(config: RunConfig): Server {
       },
     },
     requestHandlers: {
-      ["initialize"](params: lsp.InitializeParams) {
+      ["initialize"](params: lsp.InitializeParams): lsp.InitializeResult {
         if (params.workspaceFolders) {
           // TODO: traverse workspaces and find project directories
           projectPaths = params.workspaceFolders.map(({ uri }) => uri).sort()
@@ -62,9 +62,11 @@ export function run(config: RunConfig): Server {
             version: "0.0.1",
           },
         };
-        return Promise.resolve(result);
+        return result;
       },
-      async ["textDocument/definition"](params: any) {
+      async ["textDocument/definition"](
+        params: lsp.DefinitionParams,
+      ): Promise<lsp.DefinitionResponse> {
         const { textDocument, position } = params;
         const schema = await buildFreshSchema(textDocument.uri);
         const location = gotoDefinition(
@@ -72,9 +74,11 @@ export function run(config: RunConfig): Server {
           textDocument.uri,
           positionToColRow(position),
         );
-        return location && locationToLspLocation(location);
+        return location ? locationToLspLocation(location) : null;
       },
-      async ["textDocument/references"](params: any) {
+      async ["textDocument/references"](
+        params: lsp.ReferenceParams,
+      ): Promise<lsp.ReferenceResponse> {
         const { textDocument, position } = params;
         const schema = await buildFreshSchema(textDocument.uri);
         const locations = findAllReferences(

--- a/language-server/server.ts
+++ b/language-server/server.ts
@@ -4,10 +4,11 @@ import gotoDefinition from "../core/schema/gotoDefinition.ts";
 import { build } from "../core/schema/builder.ts";
 import { createJsonRpcConnection, CreateJsonRpcLogConfig } from "./json-rpc.ts";
 import { ColRow } from "../core/parser/recursive-descent-parser.ts";
-import { Location as PbkitLocation } from "../core/parser/location.ts";
+import { Location } from "../core/parser/location.ts";
 import { Schema } from "../core/schema/model.ts";
 import findAllReferences from "../core/schema/findAllReferences.ts";
 import expandEntryPaths from "../cli/pb/cmds/gen/expandEntryPaths.ts";
+import * as lsp from "./lsp.ts";
 
 export interface RunConfig {
   reader: Deno.Reader;
@@ -16,50 +17,6 @@ export interface RunConfig {
 }
 export interface Server {
   finish(): void;
-}
-
-interface WorkspaceFolder {
-  uri: string;
-  name: string;
-}
-
-interface InitializeParams {
-  workspaceFolders?: WorkspaceFolder[] | null;
-}
-
-interface InitializeResult {
-  capabilities: ServerCapabilities;
-  serverInfo?: {
-    name: string;
-    version?: string;
-  };
-}
-
-enum TextDocumentSyncKind {
-  None = 0,
-  Full = 1,
-  Incremental = 2,
-}
-interface CompletionOptions {
-  resolveProvider?: boolean;
-  completionItem?: {
-    labelDetailsSupport?: boolean;
-  };
-}
-interface ServerCapabilities {
-  textDocumentSync?: TextDocumentSyncKind;
-  completionProvider?: CompletionOptions;
-  hoverProvider?: boolean;
-  declarationProvider?: boolean; // @TODO: Add Support for DeclarationRegistrationOptions
-  definitionProvider?: boolean; // @TODO: Add Support for DefinitionOptions
-  typeDefinitionProvider?: boolean; // @TODO: Add Support for TypeDefinitionRegistrationOptions
-  implementationProvider?: boolean; // @TODO: Add Support for ImplementationRegistrationOptions
-  referencesProvider?: boolean;
-  workspace?: {
-    workspaceFolders?: {
-      supported?: boolean;
-    };
-  };
 }
 
 export function run(config: RunConfig): Server {
@@ -76,17 +33,17 @@ export function run(config: RunConfig): Server {
       },
     },
     requestHandlers: {
-      ["initialize"](params: InitializeParams) {
+      ["initialize"](params: lsp.InitializeParams) {
         if (params.workspaceFolders) {
           // TODO: traverse workspaces and find project directories
           projectPaths = params.workspaceFolders.map(({ uri }) => uri).sort()
             .reverse();
         }
         // Find .pollapo paths in workspace folders
-        const result: InitializeResult = {
+        const result: lsp.InitializeResult = {
           capabilities: {
             // @TODO: Add support for incremental sync
-            textDocumentSync: TextDocumentSyncKind.Full,
+            textDocumentSync: lsp.TextDocumentSyncKind.Full,
             completionProvider: {
               // @TODO: Add support for resolveProvider
               resolveProvider: false,
@@ -115,7 +72,7 @@ export function run(config: RunConfig): Server {
           textDocument.uri,
           positionToColRow(position),
         );
-        return location && pbkitLocationToLspLocation(location);
+        return location && locationToLspLocation(location);
       },
       async ["textDocument/references"](params: any) {
         const { textDocument, position } = params;
@@ -125,7 +82,7 @@ export function run(config: RunConfig): Server {
           textDocument.uri,
           positionToColRow(position),
         );
-        return locations.map(pbkitLocationToLspLocation);
+        return locations.map(locationToLspLocation);
       },
     },
   });
@@ -144,7 +101,7 @@ export function run(config: RunConfig): Server {
   }
 }
 
-function pbkitLocationToLspLocation(location: PbkitLocation): LspLocation {
+function locationToLspLocation(location: Location): lsp.Location {
   return {
     uri: location.filePath,
     range: {
@@ -154,25 +111,13 @@ function pbkitLocationToLspLocation(location: PbkitLocation): LspLocation {
   };
 }
 
-interface LspLocation {
-  uri: string;
-  range: {
-    start: Position;
-    end: Position;
-  };
-}
-
-interface Position {
-  character: number;
-  line: number;
-}
-function positionToColRow(position: Position): ColRow {
+function positionToColRow(position: lsp.Position): ColRow {
   return {
     col: position.character,
     row: position.line,
   };
 }
-function colRowToPosition(colRow: ColRow): Position {
+function colRowToPosition(colRow: ColRow): lsp.Position {
   return {
     character: colRow.col,
     line: colRow.row,


### PR DESCRIPTION
- lsp.ts를 추가했습니다. → Location, Position, Initialize 관련한 Type들을 모두 옮겼습니다.
- lsp namespace로 사용하게끔 변경하였습니다.
- requestHandler의 return type이 Promise가 아닌 경우에도 대응되도록 변경합니다.