### PR TITLE
feat(lsp/reference): Allow find typePath from `ast.Type` node

### DIFF
--- a/core/schema/builder.ts
+++ b/core/schema/builder.ts
@@ -417,7 +417,7 @@ function getDescription(commentGroups: ast.CommentGroup[]): string {
   return parseDocComment(docComment?.text ?? "");
 }
 
-type ResolveTypePathFn = (
+export type ResolveTypePathFn = (
   type: string,
   scope: `.${string}`,
 ) => string | undefined;


### PR DESCRIPTION
MessageName 부분에서만 reference 동작이 가능하던 것을 필드 타입에서도 사용할 수 있게끔 수정합니다.