### PR TITLE
fix(decodeJson): Fix possible / repeated enum bug in decodeJson

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -925,7 +925,7 @@ export function getDefaultJsonValueToTsValueCode({
       return `${jsonValueToTsValueFns}.${typePath.substr(1)}(${jsonValue})`;
     }
     if (field.isEnum) {
-      return `${jsonValueToTsValueFns}.enum(${jsonValue}) as ${tsType}`;
+      return `${jsonValueToTsValueFns}.enum(${jsonValue}) as ${field.tsType}`;
     }
     const decodeJson = importBuffer.addInternalImport(
       filePath,

--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -906,7 +906,7 @@ export function getDefaultJsonValueToTsValueCode({
     const { typePath } = schema;
     if (!typePath) return;
     const typePathCode = typePathToCode("value", typePath);
-    return `value.${tsName}.map((value: any) => ${typePathCode})`;
+    return `value.${tsName}?.map((value: any) => ${typePathCode})`;
   }
   const { typePath } = schema;
   return typePathToCode("value." + tsName, typePath, tsType);

--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -895,7 +895,7 @@ export function getDefaultJsonValueToTsValueCode({
   field,
   messages,
 }: GetDefaultJsonValueToTsValueCodeConfig): string | undefined {
-  const { schema, tsName, tsType } = field;
+  const { schema, tsName } = field;
   if (schema.kind === "map") {
     const { keyTypePath, valueTypePath } = schema;
     if (!keyTypePath || !valueTypePath) return;
@@ -909,11 +909,10 @@ export function getDefaultJsonValueToTsValueCode({
     return `value.${tsName}?.map((value: any) => ${typePathCode})`;
   }
   const { typePath } = schema;
-  return typePathToCode("value." + tsName, typePath, tsType);
+  return typePathToCode("value." + tsName, typePath);
   function typePathToCode(
     jsonValue: string,
     typePath?: string,
-    tsType?: string,
   ) {
     if (!typePath) return;
     const jsonValueToTsValueFns = importBuffer.addRuntimeImport(


### PR DESCRIPTION
- decodeJson의 repeated field인 경우 value의 유무를 검증하지 않는데, value가 없는 경우 ?? [] 로 fallback되지 못하고 error를 낼 수 있어 optional chaining operator를 추가합니다. https://github.com/pbkit/pbkit/commit/6b692e871daef1be6329ff73f363636bf03a793d
- getDefaultJsonValueToTsValueCode > typePathToCode에서 repeated인 경우 tsType을 기입하지 않아 발생한 문제인데, 실제로 typePathToCode의 인자로 tsType을 context와 다르게 주입해야 하는 경우가 없어 삭제합니다. ba8088a6c5be1d22d5ab07bbb82f6718a1357aee f63eb49

resolves #178