### PR TITLE
fix(codegen/binary): Fix repeated packed enum decode bug

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -633,6 +633,21 @@ const getDecodeBinaryCode: GetCodeFn = ({
           );
           wireValuesToTsValuesCode =
             `Array.from(${unpackFns}.${type}(wireValues))`;
+        } else if (field.isEnum) {
+          const unpackFns = importBuffer.addRuntimeImport(
+            filePath,
+            "wire/scalar.ts",
+            "unpackFns",
+          );
+          const typePath = (schema as schema.RepeatedField).typePath;
+          if (!typePath) return;
+          const num2name = importBuffer.addInternalImport(
+            filePath,
+            getFilePath(typePath, messages),
+            "num2name",
+          );
+          wireValuesToTsValuesCode =
+            `Array.from(${unpackFns}.int32(wireValues)).map(num => ${num2name}[num as keyof typeof ${num2name}])`;
         } else {
           wireValuesToTsValuesCode =
             `wireValues.map((wireValue) => ${wireValueToTsValueCode}).filter(x => x !== undefined)`;

--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -623,7 +623,8 @@ const getDecodeBinaryCode: GetCodeFn = ({
       if (!wireValueToTsValueCode) return "";
       const isCollection = message.collectionFieldNumbers.has(fieldNumber);
       if (isCollection) {
-        const type = (schema as schema.RepeatedField).typePath?.substr(1);
+        const typePath = (schema as schema.RepeatedField).typePath;
+        const type = typePath?.slice(1);
         let wireValuesToTsValuesCode: string;
         if (type as keyof typeof unpackFns in unpackFns) {
           const unpackFns = importBuffer.addRuntimeImport(
@@ -633,14 +634,12 @@ const getDecodeBinaryCode: GetCodeFn = ({
           );
           wireValuesToTsValuesCode =
             `Array.from(${unpackFns}.${type}(wireValues))`;
-        } else if (field.isEnum) {
+        } else if (field.isEnum && typePath) {
           const unpackFns = importBuffer.addRuntimeImport(
             filePath,
             "wire/scalar.ts",
             "unpackFns",
           );
-          const typePath = (schema as schema.RepeatedField).typePath;
-          if (!typePath) return;
           const num2name = importBuffer.addInternalImport(
             filePath,
             getFilePath(typePath, messages),


### PR DESCRIPTION
- Fix decoding repeated enum field with packed option

## as-is
```typescript
collection: {
	  const wireValues = wireMessage.filter(([fieldNumber]) => fieldNumber === 1).map(([, wireValue]) => wireValue);
	  const value = wireValues.map((wireValue) => wireValue.type === WireType.Varint ? num2name[wireValue.value[0] as keyof typeof num2name] : undefined).filter(x => x !== undefined);
	  if (!value.length) break collection;
	  result.babo = value as any;
}
```

## to-be
```typescript
collection: {
	  const wireValues = wireMessage.filter(([fieldNumber]) => fieldNumber === 1).map(([, wireValue]) => wireValue);
	  const value = Array.from(unpackFns.int32(wireValues)).map(num => num2name[num as keyof typeof num2name]);
	  if (!value.length) break collection;
	  result.babo = value as any;
}
```

resolve #186 