### PR TITLE
language-server - special handling for pollapo repositories

### DIFF
--- a/cli/pb/cmds/gen/expandEntryPaths.ts
+++ b/cli/pb/cmds/gen/expandEntryPaths.ts
@@ -12,10 +12,12 @@ export default async function expandEntryPaths(
     const entryPath = _entryPath.startsWith("file://")
       ? fromFileUrl(_entryPath)
       : _entryPath;
-    const entries = walk(entryPath, { includeDirs: false, exts: [".proto"] });
-    for await (const { path } of entries) {
-      result.push(relative(entryPath, path));
-    }
+    try {
+      const entries = walk(entryPath, { includeDirs: false, exts: [".proto"] });
+      for await (const { path } of entries) {
+        result.push(relative(entryPath, path));
+      }
+    } catch {}
   }
   return result;
 }

--- a/cli/pollapo/pollapoYml.ts
+++ b/cli/pollapo/pollapoYml.ts
@@ -13,6 +13,7 @@ import { getRevType } from "./rev.ts";
 import { YAMLError } from "https://deno.land/std@0.122.0/encoding/_yaml/error.ts";
 
 export type PollapoYml = {
+  repo?: string;
   deps?: string[];
   root?: PollapoRoot;
 } | undefined;

--- a/core/loader/combineLoader.ts
+++ b/core/loader/combineLoader.ts
@@ -1,0 +1,12 @@
+import { Loader } from "./index.ts";
+
+export default function combineLoader(a: Loader, b: Loader): Loader {
+  return {
+    async load(path) {
+      return (
+        (await a.load(path)) ||
+        (await b.load(path))
+      );
+    },
+  };
+}

--- a/core/loader/deno-fs.ts
+++ b/core/loader/deno-fs.ts
@@ -1,9 +1,9 @@
 import { exists } from "https://deno.land/std@0.122.0/fs/exists.ts";
 import {
-  fromFileUrl,
+  fromFileUrl as _fromFileUrl,
   isAbsolute,
-  resolve,
-} from "https://deno.land/std@0.122.0/path/mod.ts";
+  resolve as _resolve,
+} from "https://deno.land/std@0.122.0/path/posix.ts";
 import { Loader } from "./index.ts";
 
 export interface CreateLoaderConfig {
@@ -15,14 +15,14 @@ export function createLoader(
   return {
     async load(path) {
       if (isFileUrl(path) || isAbsolute(path)) {
-        const filePath = _fromFileUrl(path);
-        const absolutePath = _resolve(filePath);
+        const filePath = fromFileUrl(path);
+        const absolutePath = resolve(filePath);
         if (!await exists(filePath)) return null;
         return { absolutePath, data: await Deno.readTextFile(filePath) };
       }
       for (const root of config.roots) {
-        const absolutePath = _resolve(root, path);
-        const filePath = _fromFileUrl(absolutePath);
+        const absolutePath = resolve(root, path);
+        const filePath = fromFileUrl(absolutePath);
         if (!await exists(filePath)) continue;
         return { absolutePath, data: await Deno.readTextFile(filePath) };
       }
@@ -35,11 +35,11 @@ function isFileUrl(path: string): boolean {
   return path.startsWith("file://");
 }
 
-function _resolve(absolutePath: string, subPath: string = ""): string {
-  return "file://" + resolve(_fromFileUrl(absolutePath), subPath);
+export function resolve(absolutePath: string, subPath: string = ""): string {
+  return "file://" + _resolve(fromFileUrl(absolutePath), subPath);
 }
 
-function _fromFileUrl(path: string): string {
+export function fromFileUrl(path: string): string {
   if (!isFileUrl(path)) return path;
-  return fromFileUrl(path);
+  return _fromFileUrl(path);
 }

--- a/core/loader/memoizeLoader.ts
+++ b/core/loader/memoizeLoader.ts
@@ -4,6 +4,7 @@ export default function memoizeLoader(l: Loader): Loader {
   const memo: { [key: string]: LoadResult | null } = {};
   return {
     async load(path) {
+      if (path in memo) return memo[path];
       return memo[path] = await l.load(path);
     },
   };

--- a/core/loader/memoizeLoader.ts
+++ b/core/loader/memoizeLoader.ts
@@ -1,0 +1,10 @@
+import { Loader, LoadResult } from "./index.ts";
+
+export default function memoizeLoader(l: Loader): Loader {
+  const memo: { [key: string]: LoadResult | null } = {};
+  return {
+    async load(path) {
+      return memo[path] = await l.load(path);
+    },
+  };
+}

--- a/core/schema/builder.ts
+++ b/core/schema/builder.ts
@@ -58,12 +58,12 @@ export async function build(config: BuildConfig): Promise<Schema> {
     const services = iterServices(statements, typePath, filePath);
     for (const [typePath, service] of services) {
       file.servicePaths.push(typePath);
-      result.services[typePath] = service;
+      if (!(typePath in result.services)) result.services[typePath] = service;
     }
     const types = iterTypes(statements, typePath, filePath);
     for (const [typePath, type] of types) {
       file.typePaths.push(typePath);
-      result.types[typePath] = type;
+      if (!(typePath in result.types)) result.types[typePath] = type;
     }
     // TODO: extends
   }

--- a/language-server/project.ts
+++ b/language-server/project.ts
@@ -59,7 +59,7 @@ async function getPollapoRepo(
   projectPath: string,
 ): Promise<string | undefined> {
   try {
-    const pollapoYmlPath = resolve(projectPath, "/pollapo.yml");
+    const pollapoYmlPath = resolve(projectPath, "pollapo.yml");
     const pollapoYml = await loadPollapoYml(fromFileUrl(pollapoYmlPath));
     if (pollapoYml?.repo) return String(pollapoYml.repo);
   } catch {}

--- a/language-server/project.ts
+++ b/language-server/project.ts
@@ -1,0 +1,78 @@
+import { exists } from "https://deno.land/std@0.122.0/fs/exists.ts";
+import { getVendorDir } from "../cli/pb/config.ts";
+import expandEntryPaths from "../cli/pb/cmds/gen/expandEntryPaths.ts";
+import { loadPollapoYml } from "../cli/pollapo/pollapoYml.ts";
+import { BuildConfig } from "../core/schema/builder.ts";
+import { Loader } from "../core/loader/index.ts";
+import combineLoader from "../core/loader/combineLoader.ts";
+import memoizeLoader from "../core/loader/memoizeLoader.ts";
+import {
+  createLoader as createDenoFsLoader,
+  fromFileUrl,
+  resolve,
+} from "../core/loader/deno-fs.ts";
+
+export interface ProjectManager {
+  addProjectPath(projectPath: string): Promise<void>;
+  getProjectPath(filePath: string): string | undefined;
+  createBuildConfig(filePath: string): Promise<BuildConfig>;
+}
+
+export function createProjectManager(): ProjectManager {
+  // sorted string array in descending order
+  // ex) ['file:///foo/baz', 'file:///foo/bar/baz', 'file:///foo/bar', 'file:///foo']
+  const projectPaths: string[] = [];
+  function getProjectPath(filePath: string): string | undefined {
+    return projectPaths.find((p) => filePath.startsWith(p));
+  }
+  return {
+    async addProjectPath(projectPath) {
+      projectPaths.push(projectPath);
+      projectPaths.sort().reverse();
+    },
+    getProjectPath,
+    async createBuildConfig(filePath) {
+      const projectPath = getProjectPath(filePath);
+      if (!projectPath) {
+        const denoFsLoader = createDenoFsLoader({ roots: [getVendorDir()] });
+        return { loader: memoizeLoader(denoFsLoader), files: [filePath] };
+      }
+      const entryPaths = [projectPath + "/.pollapo", projectPath];
+      const files = await expandEntryPaths(entryPaths);
+      files.push(filePath);
+      const roots = [...entryPaths, getVendorDir()];
+      const denoFsLoader = createDenoFsLoader({ roots });
+      const repo = await getPollapoRepo(projectPath);
+      if (!repo) return { loader: memoizeLoader(denoFsLoader), files };
+      return {
+        loader: memoizeLoader(combineLoader(
+          createPollapoRepoLoader(projectPath, repo),
+          denoFsLoader,
+        )),
+        files,
+      };
+    },
+  };
+}
+
+async function getPollapoRepo(
+  projectPath: string,
+): Promise<string | undefined> {
+  try {
+    const pollapoYmlPath = resolve(projectPath, "/pollapo.yml");
+    const pollapoYml = await loadPollapoYml(fromFileUrl(pollapoYmlPath));
+    if (pollapoYml?.repo) return String(pollapoYml.repo);
+  } catch {}
+}
+
+function createPollapoRepoLoader(projectPath: string, repo: string): Loader {
+  return {
+    async load(path) {
+      if (!path.startsWith(repo + "/")) return null;
+      const absolutePath = resolve(projectPath, path.slice(repo.length + 1));
+      const filePath = fromFileUrl(absolutePath);
+      if (!await exists(filePath)) return null;
+      return { absolutePath, data: await Deno.readTextFile(filePath) };
+    },
+  };
+}


### PR DESCRIPTION
When importing the repository's own file in the pollapo package repository, the import path starts from the github repository path(e.g. `username/reponame`).

There is no guarantee that the local directory name matches this, so I made a loader that reads the `repo` field of `pollapo.yml` in the package repository and handles it specially.