### PR TITLE
Throw error when there is no zero value in enum

### DIFF
--- a/core/parser/proto.regression.test.ts
+++ b/core/parser/proto.regression.test.ts
@@ -1,3 +1,4 @@
+import { assertThrows } from "https://deno.land/std@0.134.0/testing/asserts.ts";
 import { parse } from "./proto.ts";
 
 Deno.test("#39", () => {
@@ -153,3 +154,19 @@ Deno.test("#172", () => {
     }
   `);
 });
+
+Deno.test("#194", () => {
+  assertThrows(
+    () => {
+      parse(String.raw`
+         enum Lorem {
+           IPSUM = 1;
+           DOLOR = 2;
+         }
+      `)
+    },
+    Error,
+    "0",
+  )
+})
+

--- a/core/parser/proto.regression.test.ts
+++ b/core/parser/proto.regression.test.ts
@@ -36,6 +36,7 @@ Deno.test("#44", () => {
 Deno.test("#45", () => {
   parse(`
     enum EnumWithLargeValue {
+      DEFAULT = 0;
       VALUE_MAX = 0x7fffffff;
     }
   `);
@@ -69,6 +70,7 @@ Deno.test("#55", () => {
   parse(`
     enum Foo {
       reserved 1;
+      BAR = 0;
     }
   `);
 });

--- a/core/parser/proto.ts
+++ b/core/parser/proto.ts
@@ -865,6 +865,16 @@ function expectEnumBody(parser: RecursiveDescentParser): ast.EnumBody {
     acceptEnumField,
     acceptEmpty,
   ]);
+  if (statements.reduce((acc, statement) =>  {
+    switch (statement.type) {
+      case "enum-field":
+        return statement.fieldNumber.value.text === "0" || acc;
+      default:
+        return false
+    }
+  }, false) === false) {
+    throw new Error("enum must have field for 0.");
+  }
   const bracketClose = parser.expect("}");
   return {
     ...mergeSpans([bracketOpen, bracketClose]),


### PR DESCRIPTION
Make parser throw if there is no zero value in enum

PS. Please recommend something appropriate for error.

Closes #194 