### PR TITLE
fix codegen bug when generating map field

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -491,7 +491,7 @@ const getEncodeBinaryCode: GetCodeFn = ({
       if (schema.kind === "map") {
         return [
           "  {\n",
-          `    const fields = Object.entries(value.${tsName});\n`,
+          `    const fields = value.${tsName}.entries();\n`,
           "    for (const [key, value] of fields) {\n",
           "      result.push(\n",
           `        [${fieldNumber}, ${tsValueToWireValueCode}],\n`,


### PR DESCRIPTION
```sh
pb gen ts -o out google/protobuf/map_lite_unittest.proto
```

```sh
diff -u out-before/messages/protobuf_unittest/TestMapLite.ts \
        out-after/messages/protobuf_unittest/TestMapLite.ts \
        > out.diff
```
```diff
--- out-before/messages/protobuf_unittest/TestMapLite.ts
+++ out-after/messages/protobuf_unittest/TestMapLite.ts
@@ -135,7 +135,7 @@
 export function encodeBinary(value: $.protobuf_unittest.TestMapLite): Uint8Array {
   const result: WireMessage = [];
   {
-    const fields = Object.entries(value.mapInt32Int32);
+    const fields = value.mapInt32Int32.entries();
     for (const [key, value] of fields) {
       result.push(
         [1, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.int32(key)], [2, tsValueToWireValueFns.int32(value)]]) }],
@@ -143,7 +143,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapInt64Int64);
+    const fields = value.mapInt64Int64.entries();
     for (const [key, value] of fields) {
       result.push(
         [2, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.int64(key)], [2, tsValueToWireValueFns.int64(value)]]) }],
@@ -151,7 +151,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapUint32Uint32);
+    const fields = value.mapUint32Uint32.entries();
     for (const [key, value] of fields) {
       result.push(
         [3, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.uint32(key)], [2, tsValueToWireValueFns.uint32(value)]]) }],
@@ -159,7 +159,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapUint64Uint64);
+    const fields = value.mapUint64Uint64.entries();
     for (const [key, value] of fields) {
       result.push(
         [4, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.uint64(key)], [2, tsValueToWireValueFns.uint64(value)]]) }],
@@ -167,7 +167,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapSint32Sint32);
+    const fields = value.mapSint32Sint32.entries();
     for (const [key, value] of fields) {
       result.push(
         [5, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.sint32(key)], [2, tsValueToWireValueFns.sint32(value)]]) }],
@@ -175,7 +175,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapSint64Sint64);
+    const fields = value.mapSint64Sint64.entries();
     for (const [key, value] of fields) {
       result.push(
         [6, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.sint64(key)], [2, tsValueToWireValueFns.sint64(value)]]) }],
@@ -183,7 +183,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapFixed32Fixed32);
+    const fields = value.mapFixed32Fixed32.entries();
     for (const [key, value] of fields) {
       result.push(
         [7, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.fixed32(key)], [2, tsValueToWireValueFns.fixed32(value)]]) }],
@@ -191,7 +191,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapFixed64Fixed64);
+    const fields = value.mapFixed64Fixed64.entries();
     for (const [key, value] of fields) {
       result.push(
         [8, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.fixed64(key)], [2, tsValueToWireValueFns.fixed64(value)]]) }],
@@ -199,7 +199,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapSfixed32Sfixed32);
+    const fields = value.mapSfixed32Sfixed32.entries();
     for (const [key, value] of fields) {
       result.push(
         [9, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.sfixed32(key)], [2, tsValueToWireValueFns.sfixed32(value)]]) }],
@@ -207,7 +207,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapSfixed64Sfixed64);
+    const fields = value.mapSfixed64Sfixed64.entries();
     for (const [key, value] of fields) {
       result.push(
         [10, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.sfixed64(key)], [2, tsValueToWireValueFns.sfixed64(value)]]) }],
@@ -215,7 +215,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapInt32Float);
+    const fields = value.mapInt32Float.entries();
     for (const [key, value] of fields) {
       result.push(
         [11, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.int32(key)], [2, tsValueToWireValueFns.float(value)]]) }],
@@ -223,7 +223,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapInt32Double);
+    const fields = value.mapInt32Double.entries();
     for (const [key, value] of fields) {
       result.push(
         [12, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.int32(key)], [2, tsValueToWireValueFns.double(value)]]) }],
@@ -231,7 +231,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapBoolBool);
+    const fields = value.mapBoolBool.entries();
     for (const [key, value] of fields) {
       result.push(
         [13, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.bool(key)], [2, tsValueToWireValueFns.bool(value)]]) }],
@@ -239,7 +239,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapStringString);
+    const fields = value.mapStringString.entries();
     for (const [key, value] of fields) {
       result.push(
         [14, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.string(key)], [2, tsValueToWireValueFns.string(value)]]) }],
@@ -247,7 +247,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapInt32Bytes);
+    const fields = value.mapInt32Bytes.entries();
     for (const [key, value] of fields) {
       result.push(
         [15, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.int32(key)], [2, tsValueToWireValueFns.bytes(value)]]) }],
@@ -255,7 +255,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapInt32Enum);
+    const fields = value.mapInt32Enum.entries();
     for (const [key, value] of fields) {
       result.push(
         [16, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.int32(key)], [2, { type: WireType.Varint as const, value: new Long(name2num[value as keyof typeof name2num]) }]]) }],
@@ -263,7 +263,7 @@
     }
   }
   {
-    const fields = Object.entries(value.mapInt32ForeignMessage);
+    const fields = value.mapInt32ForeignMessage.entries();
     for (const [key, value] of fields) {
       result.push(
         [17, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.int32(key)], [2, { type: WireType.LengthDelimited as const, value: encodeBinary_1(value) }]]) }],
@@ -271,7 +271,7 @@
     }
   }
   {
-    const fields = Object.entries(value.teboring);
+    const fields = value.teboring.entries();
     for (const [key, value] of fields) {
       result.push(
         [18, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.int32(key)], [2, tsValueToWireValueFns.int32(value)]]) }],
```