### PR TITLE
fix: Print error message for symlink failure instead of stack trace

### DIFF
--- a/cli/pollapo/cmds/install.ts
+++ b/cli/pollapo/cmds/install.ts
@@ -36,6 +36,7 @@ import {
   lock,
   parseDep,
   PollapoRootLockTable,
+  PollapoWindowsPrivilegeNotHeldError,
   PollapoYml,
   PollapoYmlMalformedError,
   PollapoYmlNotFoundError,
@@ -120,7 +121,8 @@ export default new Command()
         err instanceof GithubRepoNotFoundError ||
         err instanceof PollapoUnauthorizedError ||
         err instanceof PollapoYmlMalformedError ||
-        err instanceof PollapoYmlNotFoundError
+        err instanceof PollapoYmlNotFoundError ||
+        err instanceof PollapoWindowsPrivilegeNotHeldError
       ) {
         await println(red("error"));
         await println(err.message);

--- a/cli/pollapo/pollapoYml.ts
+++ b/cli/pollapo/pollapoYml.ts
@@ -192,7 +192,18 @@ export async function* cacheDeps(
       const commitHash = await fetchingCommitHash;
       queue.push({ ...dep, rev: commitHash });
       await unlink(dep);
-      await link(dep, commitHash);
+      try {
+        await link(dep, commitHash);
+      } catch (err) {
+        if (Deno.build.os === "windows") {
+          console.log(
+            "Failed to symlink. Please run the command as administrator.",
+          );
+        } else {
+          console.log("Failed to symlink.");
+        }
+        Deno.exit(1);
+      }
     } else {
       const downloading = download(dep);
       yield { type: "download", dep, promise: downloading };

--- a/cli/pollapo/pollapoYml.ts
+++ b/cli/pollapo/pollapoYml.ts
@@ -200,7 +200,7 @@ export async function* cacheDeps(
             "Failed to symlink. Please run the command as administrator.",
           );
         } else {
-          console.log("Failed to symlink.");
+          console.error(red("Failed to symlink"))
         }
         Deno.exit(1);
       }


### PR DESCRIPTION
Related issue: #56 

Print `Failed to symlink. Please run the command as administrator.` instead of error message with stack trace
