### PR TITLE
codegen(swift/wrp): Add codegen for wrp-swift service provider

### DIFF
--- a/codegen/swift/index.ts
+++ b/codegen/swift/index.ts
@@ -86,7 +86,9 @@ export interface GenMessagesConfig {
 }
 export interface GenServicesConfig {
   outDir: string;
+  genTypes: ServiceType[];
 }
+export type ServiceType = "grpc" | "wrp";
 
 export function toSwiftName(typePath: string) {
   return typePath.split(".").slice(1).map((fragment) =>

--- a/codegen/swift/services.ts
+++ b/codegen/swift/services.ts
@@ -105,16 +105,16 @@ function* genService({
         return;
       }
       case "wrp": {
-        const wrpProviderCode = getWrpProviderCode(getCodeConfig);
-        const wrpProviderExtensionCode = getWrpProviderExtensionCode(
+        const providerCode = getWrpProviderCode(getCodeConfig);
+        const providerExtensionCode = getWrpProviderExtensionCode(
           getCodeConfig,
         );
         yield [
           filePath,
           new StringReader([
             importCode,
-            wrpProviderCode,
-            wrpProviderExtensionCode,
+            providerCode,
+            providerExtensionCode,
           ].join("\n")),
         ];
         return;

--- a/codegen/swift/services.ts
+++ b/codegen/swift/services.ts
@@ -348,7 +348,7 @@ const getProviderCode: GetCodeFn = ({ schema, type, swiftName }) => {
 
 const getWrpProviderCode: GetCodeFn = ({ schema, type, swiftName }) => {
   return [
-    `public protocol ${swiftName}WrpProvider: WrpHandlerProvider {\n`,
+    `public protocol ${swiftName}WrpProvider: WrpHandlerProvider {`,
     Object.entries(type.rpcs).map(
       ([rpcName, rpc]) => {
         const reqType = getSwiftFullName({


### PR DESCRIPTION
We provide new two options for generating service codes in swift.
If you want to generate grpc codegen, call `pb gen swift` with `--grpc-service` option.
To generate wrp(webview/worker request protocol) codegen, call with `--wrp-service`.
If you don't provide any service option, no service code will be generated.
You can provide both options together. the generated service codes will be separated. (like `a.grpc.swift`, `a.wrp.swift`)