### PR TITLE
compat/file-descriptor-set: Enhance `convertSchemaToFileDescriptorSet` 

### DIFF
--- a/cli/pb/cmds/decode/cmds/file-descriptor-set.ts
+++ b/cli/pb/cmds/decode/cmds/file-descriptor-set.ts
@@ -1,0 +1,26 @@
+import { Command } from "https://deno.land/x/cliffy@v0.19.5/command/mod.ts";
+import {
+  readAll,
+  writeAll,
+} from "https://deno.land/std@0.136.0/streams/conversion.ts";
+import { encode } from "../../../../../compat/protoc/text-format.ts";
+import deserialize from "../../../../../core/runtime/wire/deserialize.ts";
+import { createLoader } from "../../../../../core/loader/deno-fs.ts";
+import { build } from "../../../../../core/schema/builder.ts";
+import { getVendorDir } from "../../../config.ts";
+
+export default new Command()
+  .description(
+    "Read an file descriptor set message from standard input and write in text format to standard output.",
+  )
+  .action(async () => {
+    const typePath = ".google.protobuf.FileDescriptorSet";
+    const roots = [getVendorDir()];
+    const loader = createLoader({ roots });
+    const files = ["google/protobuf/descriptor.proto"];
+    const schema = await build({ loader, files });
+    const stdin = await readAll(Deno.stdin);
+    const wireMessage = deserialize(stdin);
+    const text = encode(wireMessage, { schema, typePath });
+    await writeAll(Deno.stdout, new TextEncoder().encode(text));
+  });

--- a/cli/pb/cmds/decode/index.ts
+++ b/cli/pb/cmds/decode/index.ts
@@ -9,6 +9,7 @@ import { encode } from "../../../../compat/protoc/text-format.ts";
 import deserialize from "../../../../core/runtime/wire/deserialize.ts";
 import { getVendorDir } from "../../config.ts";
 import expandEntryPaths from "../gen/expandEntryPaths.ts";
+import fileDescriptorSet from "./cmds/file-descriptor-set.ts";
 import raw from "./cmds/raw.ts";
 
 interface Options {
@@ -50,5 +51,6 @@ command
     const text = encode(wireMessage, { schema, typePath });
     await writeAll(Deno.stdout, new TextEncoder().encode(text));
   })
+  .command("file-descriptor-set", fileDescriptorSet)
   .command("raw", raw);
 export default command;

--- a/cli/pb/cmds/gen/cmds/file-descriptor-set.ts
+++ b/cli/pb/cmds/gen/cmds/file-descriptor-set.ts
@@ -44,6 +44,10 @@ export default new Command()
     if (options.text) {
       const wireMessage = deserialize(fileDescroptorSetBinary);
       const typePath = ".google.protobuf.FileDescriptorSet";
+      const roots = [getVendorDir()];
+      const loader = createLoader({ roots });
+      const files = ["google/protobuf/descriptor.proto"];
+      const schema = await build({ loader, files });
       const text = encode(wireMessage, { schema, typePath });
       await writeAll(Deno.stdout, new TextEncoder().encode(text));
     } else {

--- a/compat/protoc/file-descriptor-set.ts
+++ b/compat/protoc/file-descriptor-set.ts
@@ -24,7 +24,7 @@ import {
   Label as FieldLabel,
   Type as FieldType,
 } from "../../generated/messages/google/protobuf/(FieldDescriptorProto)/index.ts";
-import { capitalize, snakeToCamel } from "../../misc/case.ts";
+import { snakeToCamel, snakeToPascal } from "../../misc/case.ts";
 import {
   Type as OptimizeMode,
 } from "../../generated/messages/google/protobuf/(FileOptions)/OptimizeMode.ts";
@@ -118,7 +118,7 @@ function convertMessageToDescriptorProto(
   for (const [fieldNumber, field] of Object.entries(messageType.type.fields)) {
     if (field.kind === "map") {
       const options = fieldDescriptorOptions(field.options);
-      const entryTypeName = `${capitalize(snakeToCamel(field.name))}Entry`;
+      const entryTypeName = `${snakeToPascal(field.name)}Entry`;
       const entryTypePath = `${messageType.typePath}.${entryTypeName}`;
       const fieldDescriptorProto: FieldDescriptorProto = {
         name: field.name,

--- a/compat/protoc/file-descriptor-set.ts
+++ b/compat/protoc/file-descriptor-set.ts
@@ -452,7 +452,6 @@ function fileDescriptorOptions(
       uninterpretedOption: [], // TODO
     };
   return result;
-
   function getOptimizeMode(optimizeFor: OptionValue): OptimizeMode | undefined {
     switch (optimizeFor) {
       case "SPEED":

--- a/compat/protoc/file-descriptor-set.ts
+++ b/compat/protoc/file-descriptor-set.ts
@@ -29,7 +29,6 @@ export function convertSchemaToFileDescriptorSet(
 ): FileDescriptorSet {
   const result: FileDescriptorSet = { file: [] };
   for (const file of Object.values(schema.files)) {
-    console.error(Deno.inspect(file));
     const typeTreeArray = typePathsToTypeTreeArray(
       schema.types,
       file.typePaths,

--- a/compat/protoc/file-descriptor-set.ts
+++ b/compat/protoc/file-descriptor-set.ts
@@ -220,7 +220,7 @@ function convertEnumToEnumDescriptorProto(
   }
   return {
     name,
-    value: [],
+    value,
     options,
     reservedRange: [], // TODO
     reservedName: [], // TODO

--- a/compat/protoc/file-descriptor-set.ts
+++ b/compat/protoc/file-descriptor-set.ts
@@ -28,6 +28,7 @@ export function convertSchemaToFileDescriptorSet(
 ): FileDescriptorSet {
   const result: FileDescriptorSet = { file: [] };
   for (const file of Object.values(schema.files)) {
+    console.error(Deno.inspect(file));
     const typeTreeArray = typePathsToTypeTreeArray(
       schema.types,
       file.typePaths,

--- a/misc/case.ts
+++ b/misc/case.ts
@@ -7,7 +7,8 @@ export function pascalToCamel(pascal: string): string {
 }
 
 const id = (x: any) => x;
-const capitalize = (word: string) => word[0].toUpperCase() + word.substr(1);
+export const capitalize = (word: string) =>
+  word[0].toUpperCase() + word.substr(1);
 const snakeToCamelRegex = /^(_*)(.*?)(_*)$/;
 const snakeToCamelReplaceFn = (...args: string[]) => {
   const [, $1, $2, $3] = args;

--- a/misc/case.ts
+++ b/misc/case.ts
@@ -2,16 +2,23 @@ export function snakeToCamel(snake: string): string {
   return snake.replace(snakeToCamelRegex, snakeToCamelReplaceFn);
 }
 
+export function snakeToPascal(snake: string): string {
+  return snake.replace(snakeToCamelRegex, snakeToPascalReplaceFn);
+}
+
 export function pascalToCamel(pascal: string): string {
-  return pascal[0].toLowerCase() + pascal.substr(1);
+  return pascal[0].toLowerCase() + pascal.slice(1);
 }
 
 const id = (x: any) => x;
-export const capitalize = (word: string) =>
-  word[0].toUpperCase() + word.substr(1);
+const capitalize = (word: string) => word[0].toUpperCase() + word.slice(1);
 const snakeToCamelRegex = /^(_*)(.*?)(_*)$/;
 const snakeToCamelReplaceFn = (...args: string[]) => {
   const [, $1, $2, $3] = args;
   const [head, ...rest] = $2.split("_");
   return `${$1}${head + rest.filter(id).map(capitalize).join("")}${$3}`;
+};
+const snakeToPascalReplaceFn = (...args: string[]) => {
+  const [, $1, $2, $3] = args;
+  return `${$1}${$2.split("_").filter(id).map(capitalize).join("")}${$3}`;
 };


### PR DESCRIPTION
This PR enhances `convertSchemaToFileDescriptorSet`

- Fix values in EnumDescriptor correctly.
- New subcommand 'pb decode file-descriptor-set' for decoding without `google/protobuf/descriptor.proto` in target schema.
- Fix subcommand `pb gen file-descriptor-set --text` to decode FileDescriptorSet correctly when the schema doesn't include `google/protobuf/descriptor.proto`.
- Supports dependencies in FileDescriptor.
- Supports all well-known options for File/Message/Enum/Field.
- Supports Map fields.  
- Supports ServiceDescriptor and MethodDescriptor.
- Pretty-print options when it is empty.

resolves many todos of #140