### PR TITLE
swift/codegen: Add exclude-path option for swift codegen

### DIFF
--- a/cli/pb/cmds/gen/cmds/swift/index.ts
+++ b/cli/pb/cmds/gen/cmds/swift/index.ts
@@ -110,7 +110,7 @@ export default new Command()
       }),
     );
     function filterFilePath(filePath: string) {
-      let flag = options.includePath
+      const flag = options.includePath
         ? includePaths.some((path) => filePath.startsWith(path))
         : true;
       return options.excludePath && flag

--- a/cli/pb/cmds/gen/cmds/swift/index.ts
+++ b/cli/pb/cmds/gen/cmds/swift/index.ts
@@ -1,4 +1,10 @@
 import { Command } from "https://deno.land/x/cliffy@v0.19.5/command/mod.ts";
+import {
+  isAbsolute,
+  normalize,
+  resolve,
+  toFileUrl,
+} from "https://deno.land/std@0.122.0/path/mod.ts";
 import { createLoader } from "../../../../../../core/loader/deno-fs.ts";
 import { build } from "../../../../../../core/schema/builder.ts";
 import save from "../../../../../../codegen/save.ts";
@@ -9,6 +15,7 @@ import expandEntryPaths from "../../expandEntryPaths.ts";
 interface Options {
   entryPath?: string[];
   protoPath?: string[];
+  excludePath?: string[];
   messagesDir: string;
   servicesDir: string;
   grpcService?: boolean;
@@ -44,6 +51,11 @@ export default new Command()
     { default: "out" },
   )
   .option(
+    "--exclude-path <dir:string>",
+    "Specify the directory containing proto files to exclude codegen.",
+    { collect: true },
+  )
+  .option(
     "--grpc-service",
     "Generate gRPC service codes.",
   )
@@ -55,6 +67,9 @@ export default new Command()
   .action(async (options: Options, protoFiles: string[] = []) => {
     const entryPaths = options.entryPath ?? [];
     const protoPaths = options.protoPath ?? [];
+    const excludePaths = (options.excludePath ?? []).map((path) =>
+      toFileUrl(normalize(resolve(path))).href
+    );
     const roots = [...entryPaths, ...protoPaths, Deno.cwd(), getVendorDir()];
     const loader = createLoader({ roots });
     const files = [
@@ -71,10 +86,11 @@ export default new Command()
     await save(
       options.outDir,
       gen(schema, {
-        messages: { outDir: options.messagesDir.trim() },
+        messages: { outDir: options.messagesDir.trim(), excludePaths },
         services: {
           outDir: options.servicesDir.trim(),
           genTypes: serviceType,
+          excludePaths,
         },
       }),
     );

--- a/cli/pb/cmds/gen/cmds/swift/index.ts
+++ b/cli/pb/cmds/gen/cmds/swift/index.ts
@@ -86,9 +86,6 @@ export default new Command()
       ...protoFiles,
     ];
     const schema = await build({ loader, files });
-    if (options.includePath && options.excludePath) {
-      throw new Error("--include-path and --exclude-path are exclusive.");
-    }
     const typePaths = Object.entries(schema.types).filter(([_, value]) =>
       filterFilePath(value.filePath)
     ).map(([typePath]) => typePath as `.${string}`);
@@ -113,12 +110,11 @@ export default new Command()
       }),
     );
     function filterFilePath(filePath: string) {
-      if (options.includePath) {
-        return includePaths.some((path) => filePath.startsWith(path));
-      }
-      if (options.excludePath) {
-        return !excludePaths.some((path) => filePath.startsWith(path));
-      }
-      return true;
+      let flag = options.includePath
+        ? includePaths.some((path) => filePath.startsWith(path))
+        : true;
+      return options.excludePath && flag
+        ? !excludePaths.some((path) => filePath.startsWith(path))
+        : flag;
     }
   });

--- a/cli/pb/cmds/gen/cmds/swift/index.ts
+++ b/cli/pb/cmds/gen/cmds/swift/index.ts
@@ -110,11 +110,8 @@ export default new Command()
       }),
     );
     function filterFilePath(filePath: string) {
-      const flag = options.includePath
-        ? includePaths.some((path) => filePath.startsWith(path))
-        : true;
-      return options.excludePath && flag
-        ? !excludePaths.some((path) => filePath.startsWith(path))
-        : flag;
+      return (!options.includePath ||
+        includePaths.some((path) => filePath.startsWith(path))) &&
+        !excludePaths.some((path) => filePath.startsWith(path));
     }
   });

--- a/codegen/swift/index.ts
+++ b/codegen/swift/index.ts
@@ -82,12 +82,12 @@ export type GenRuntimeConfig = {
 };
 export interface GenMessagesConfig {
   outDir: string;
-  excludePaths: string[];
+  typePaths?: `.${string}`[];
 }
 export interface GenServicesConfig {
   outDir: string;
-  excludePaths: string[];
   genTypes: ServiceType[];
+  servicePaths?: `.${string}`[];
 }
 export type ServiceType = "grpc" | "wrp";
 

--- a/codegen/swift/index.ts
+++ b/codegen/swift/index.ts
@@ -54,7 +54,6 @@ async function* genBuildUnit(
   });
   yield* genServices(schema, {
     customTypeMapping,
-    messages,
     services,
   });
 }
@@ -83,9 +82,11 @@ export type GenRuntimeConfig = {
 };
 export interface GenMessagesConfig {
   outDir: string;
+  excludePaths: string[];
 }
 export interface GenServicesConfig {
   outDir: string;
+  excludePaths: string[];
   genTypes: ServiceType[];
 }
 export type ServiceType = "grpc" | "wrp";

--- a/codegen/swift/messages.ts
+++ b/codegen/swift/messages.ts
@@ -28,12 +28,9 @@ export default function* gen(
   config: GenConfig,
 ): Generator<CodeEntry> {
   const { messages, customTypeMapping } = config;
-  const types = Object.entries(schema.types).filter(([_, value]) =>
-    !messages.excludePaths.some((excludePath) =>
-      value.filePath.startsWith(excludePath)
-    )
-  );
-  for (const [typePath, type] of types) {
+  const typePaths = messages.typePaths ?? Object.keys(schema.types);
+  for (const typePath of typePaths) {
+    const type = schema.types[typePath];
     // Dependent on SwiftProtobuf's well-known types codegen (ex. .google.protobuf.Timestamp)
     if (typePath.startsWith(".google.protobuf")) continue;
     switch (type.kind) {

--- a/codegen/swift/services.ts
+++ b/codegen/swift/services.ts
@@ -14,7 +14,6 @@ import { toCamelCase } from "./swift-protobuf/name.ts";
 
 export interface GenConfig {
   customTypeMapping: CustomTypeMapping;
-  messages: GenMessagesConfig;
   services: GenServicesConfig;
 }
 
@@ -22,14 +21,13 @@ export default function* gen(
   schema: Schema,
   config: GenConfig,
 ) {
-  const { customTypeMapping, messages, services } = config;
+  const { customTypeMapping, services } = config;
   for (const [typePath, type] of Object.entries(schema.services)) {
     yield* genService({
       typePath,
       type,
       customTypeMapping,
       schema,
-      messages,
       services,
     });
   }
@@ -52,7 +50,6 @@ interface GenServiceConfig {
   type: Service;
   schema: Schema;
   customTypeMapping: CustomTypeMapping;
-  messages: GenMessagesConfig;
   services: GenServicesConfig;
 }
 function* genService({
@@ -60,7 +57,6 @@ function* genService({
   type,
   customTypeMapping,
   schema,
-  messages,
   services,
 }: GenServiceConfig): Generator<CodeEntry> {
   const serviceName = typePath.split(".").slice(1).join(".");

--- a/codegen/swift/services.ts
+++ b/codegen/swift/services.ts
@@ -22,7 +22,9 @@ export default function* gen(
   config: GenConfig,
 ) {
   const { customTypeMapping, services } = config;
-  for (const [typePath, type] of Object.entries(schema.services)) {
+  const servicePaths = services.servicePaths ?? Object.keys(schema.services);
+  for (const typePath of servicePaths) {
+    const type = schema.services[typePath];
     yield* genService({
       typePath,
       type,


### PR DESCRIPTION
question: how can we handle the all kinds of paths elegantly? like `~/merong`