### PR TITLE
support `buf.work.yaml`

### DIFF
--- a/compat/buf/workspace.ts
+++ b/compat/buf/workspace.ts
@@ -1,0 +1,13 @@
+import { parse as parseYaml } from "https://deno.land/std@0.147.0/encoding/yaml.ts";
+
+export interface BufWorkYaml {
+  version: "v1";
+  directories: string[];
+}
+
+export function parseBufWorkYaml(text: string): BufWorkYaml {
+  const yaml = parseYaml(text) as any;
+  const result = { version: String(yaml.version || "v1") } as BufWorkYaml;
+  result.directories = Array.isArray(yaml.directories) ? yaml.directories : [];
+  return result;
+}


### PR DESCRIPTION
https://docs.buf.build/configuration/v1/buf-work-yaml

프로젝트에 `buf.work.yaml` 파일이 있다면 다른 추가 설정 없이 language server가 똑바로 돌아가게 만들었습니다.
