### PR TITLE
fix(codegen/wrp-kt): fix default outerclass behavior

### DIFF
--- a/codegen/kt/wrp.ts
+++ b/codegen/kt/wrp.ts
@@ -280,13 +280,8 @@ function getJavaOuterClassname(schema: Schema, filePath: string): string {
     ],
   ): boolean {
     const type = typePath.split(".").pop()!;
-    if (
-      typeFilePath === filePath &&
-      defaultJavaOuterClassname.toUpperCase() === type.toUpperCase()
-    ) {
-      return true;
-    }
-    return false;
+    return typeFilePath === filePath &&
+      defaultJavaOuterClassname.toUpperCase() === type.toUpperCase();
   }
 }
 


### PR DESCRIPTION
1. if there is an `java_outer_classname` option, use it (TODO: throw an error on `RealNameOuterClass` is given. protoc does.)
2. check all types'(including service) name if it is same with outer class name regardless of its cases, add `OuterClass` suffix for resolving outer class name.

This issue can be resolved with following steps:
1. rename file name or type name with non-conflict one.
2. add `java_outer_classname` option.