### PR TITLE
feat(codegen/ts): Change typegen to type alias

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -303,8 +303,8 @@ const getMessageTypeDefCode: GetCodeFn = (config) => {
   if (message.fields.length) typeBodyCodes.push(getFieldsCode());
   if (message.oneofFields.length) typeBodyCodes.push(getOneofsCode());
   return getTypeDefCodeBase(config, (typeName) => {
-    if (!typeBodyCodes.length) return `  export interface ${typeName} {}\n`;
-    return `  export interface ${typeName} {\n${typeBodyCodes.join("")}  }\n`;
+    if (!typeBodyCodes.length) return `  export type ${typeName} = {}\n`;
+    return `  export type ${typeName} = {\n${typeBodyCodes.join("")}  }\n`;
   });
   function getFieldsCode() {
     return message.fields.map((field) => {

--- a/generated/messages/google/protobuf/(DescriptorProto)/ExtensionRange.ts
+++ b/generated/messages/google/protobuf/(DescriptorProto)/ExtensionRange.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.DescriptorProto {
-  export interface ExtensionRange {
+  export type ExtensionRange = {
     start?: number;
     end?: number;
     options?: ExtensionRangeOptions;

--- a/generated/messages/google/protobuf/(DescriptorProto)/ReservedRange.ts
+++ b/generated/messages/google/protobuf/(DescriptorProto)/ReservedRange.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.DescriptorProto {
-  export interface ReservedRange {
+  export type ReservedRange = {
     start?: number;
     end?: number;
   }

--- a/generated/messages/google/protobuf/(EnumDescriptorProto)/EnumReservedRange.ts
+++ b/generated/messages/google/protobuf/(EnumDescriptorProto)/EnumReservedRange.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.EnumDescriptorProto {
-  export interface EnumReservedRange {
+  export type EnumReservedRange = {
     start?: number;
     end?: number;
   }

--- a/generated/messages/google/protobuf/(GeneratedCodeInfo)/(Annotation)/Semantic.ts
+++ b/generated/messages/google/protobuf/(GeneratedCodeInfo)/(Annotation)/Semantic.ts
@@ -1,0 +1,19 @@
+export declare namespace $.google.protobuf.GeneratedCodeInfo.Annotation {
+  export type Semantic =
+    | "NONE"
+    | "SET"
+    | "ALIAS";
+}
+export type Type = $.google.protobuf.GeneratedCodeInfo.Annotation.Semantic;
+
+export const num2name = {
+  0: "NONE",
+  1: "SET",
+  2: "ALIAS",
+} as const;
+
+export const name2num = {
+  NONE: 0,
+  SET: 1,
+  ALIAS: 2,
+} as const;

--- a/generated/messages/google/protobuf/(GeneratedCodeInfo)/(Annotation)/index.ts
+++ b/generated/messages/google/protobuf/(GeneratedCodeInfo)/(Annotation)/index.ts
@@ -1,0 +1,1 @@
+export type { Type as Semantic } from "./Semantic.ts";

--- a/generated/messages/google/protobuf/(GeneratedCodeInfo)/Annotation.ts
+++ b/generated/messages/google/protobuf/(GeneratedCodeInfo)/Annotation.ts
@@ -1,9 +1,15 @@
 import {
+  Type as Semantic,
+  name2num,
+  num2name,
+} from "./(Annotation)/Semantic.ts";
+import {
   tsValueToJsonValueFns,
   jsonValueToTsValueFns,
 } from "../../../../../core/runtime/json/scalar.ts";
 import {
   WireMessage,
+  WireType,
 } from "../../../../../core/runtime/wire/index.ts";
 import {
   default as serialize,
@@ -14,15 +20,19 @@ import {
   unpackFns,
 } from "../../../../../core/runtime/wire/scalar.ts";
 import {
+  default as Long,
+} from "../../../../../core/runtime/Long.ts";
+import {
   default as deserialize,
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.GeneratedCodeInfo {
-  export interface Annotation {
+  export type Annotation = {
     path: number[];
     sourceFile?: string;
     begin?: number;
     end?: number;
+    semantic?: Semantic;
   }
 }
 export type Type = $.google.protobuf.GeneratedCodeInfo.Annotation;
@@ -33,6 +43,7 @@ export function getDefaultValue(): $.google.protobuf.GeneratedCodeInfo.Annotatio
     sourceFile: "",
     begin: 0,
     end: 0,
+    semantic: "NONE",
   };
 }
 
@@ -49,6 +60,7 @@ export function encodeJson(value: $.google.protobuf.GeneratedCodeInfo.Annotation
   if (value.sourceFile !== undefined) result.sourceFile = tsValueToJsonValueFns.string(value.sourceFile);
   if (value.begin !== undefined) result.begin = tsValueToJsonValueFns.int32(value.begin);
   if (value.end !== undefined) result.end = tsValueToJsonValueFns.int32(value.end);
+  if (value.semantic !== undefined) result.semantic = tsValueToJsonValueFns.enum(value.semantic);
   return result;
 }
 
@@ -58,6 +70,7 @@ export function decodeJson(value: any): $.google.protobuf.GeneratedCodeInfo.Anno
   if (value.sourceFile !== undefined) result.sourceFile = jsonValueToTsValueFns.string(value.sourceFile);
   if (value.begin !== undefined) result.begin = jsonValueToTsValueFns.int32(value.begin);
   if (value.end !== undefined) result.end = jsonValueToTsValueFns.int32(value.end);
+  if (value.semantic !== undefined) result.semantic = jsonValueToTsValueFns.enum(value.semantic) as Semantic;
   return result;
 }
 
@@ -84,6 +97,12 @@ export function encodeBinary(value: $.google.protobuf.GeneratedCodeInfo.Annotati
     const tsValue = value.end;
     result.push(
       [4, tsValueToWireValueFns.int32(tsValue)],
+    );
+  }
+  if (value.semantic !== undefined) {
+    const tsValue = value.semantic;
+    result.push(
+      [5, { type: WireType.Varint as const, value: new Long(name2num[tsValue as keyof typeof name2num]) }],
     );
   }
   return serialize(result);
@@ -119,6 +138,13 @@ export function decodeBinary(binary: Uint8Array): $.google.protobuf.GeneratedCod
     const value = wireValueToTsValueFns.int32(wireValue);
     if (value === undefined) break field;
     result.end = value;
+  }
+  field: {
+    const wireValue = wireFields.get(5);
+    if (wireValue === undefined) break field;
+    const value = wireValue.type === WireType.Varint ? num2name[wireValue.value[0] as keyof typeof num2name] : undefined;
+    if (value === undefined) break field;
+    result.semantic = value;
   }
   return result;
 }

--- a/generated/messages/google/protobuf/(SourceCodeInfo)/Location.ts
+++ b/generated/messages/google/protobuf/(SourceCodeInfo)/Location.ts
@@ -18,7 +18,7 @@ import {
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.SourceCodeInfo {
-  export interface Location {
+  export type Location = {
     path: number[];
     span: number[];
     leadingComments?: string;

--- a/generated/messages/google/protobuf/(UninterpretedOption)/NamePart.ts
+++ b/generated/messages/google/protobuf/(UninterpretedOption)/NamePart.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.UninterpretedOption {
-  export interface NamePart {
+  export type NamePart = {
     namePart: string;
     isExtension: boolean;
   }

--- a/generated/messages/google/protobuf/DescriptorProto.ts
+++ b/generated/messages/google/protobuf/DescriptorProto.ts
@@ -67,7 +67,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface DescriptorProto {
+  export type DescriptorProto = {
     name?: string;
     field: FieldDescriptorProto[];
     nestedType: DescriptorProto_1[];

--- a/generated/messages/google/protobuf/EnumDescriptorProto.ts
+++ b/generated/messages/google/protobuf/EnumDescriptorProto.ts
@@ -39,7 +39,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface EnumDescriptorProto {
+  export type EnumDescriptorProto = {
     name?: string;
     value: EnumValueDescriptorProto[];
     options?: EnumOptions;

--- a/generated/messages/google/protobuf/EnumOptions.ts
+++ b/generated/messages/google/protobuf/EnumOptions.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface EnumOptions {
+  export type EnumOptions = {
     allowAlias?: boolean;
     deprecated?: boolean;
     uninterpretedOption: UninterpretedOption[];

--- a/generated/messages/google/protobuf/EnumValueDescriptorProto.ts
+++ b/generated/messages/google/protobuf/EnumValueDescriptorProto.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface EnumValueDescriptorProto {
+  export type EnumValueDescriptorProto = {
     name?: string;
     number?: number;
     options?: EnumValueOptions;

--- a/generated/messages/google/protobuf/EnumValueOptions.ts
+++ b/generated/messages/google/protobuf/EnumValueOptions.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface EnumValueOptions {
+  export type EnumValueOptions = {
     deprecated?: boolean;
     uninterpretedOption: UninterpretedOption[];
   }

--- a/generated/messages/google/protobuf/ExtensionRangeOptions.ts
+++ b/generated/messages/google/protobuf/ExtensionRangeOptions.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface ExtensionRangeOptions {
+  export type ExtensionRangeOptions = {
     uninterpretedOption: UninterpretedOption[];
   }
 }

--- a/generated/messages/google/protobuf/FieldDescriptorProto.ts
+++ b/generated/messages/google/protobuf/FieldDescriptorProto.ts
@@ -38,7 +38,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface FieldDescriptorProto {
+  export type FieldDescriptorProto = {
     name?: string;
     extendee?: string;
     number?: number;

--- a/generated/messages/google/protobuf/FieldOptions.ts
+++ b/generated/messages/google/protobuf/FieldOptions.ts
@@ -38,7 +38,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface FieldOptions {
+  export type FieldOptions = {
     ctype?: CType;
     packed?: boolean;
     deprecated?: boolean;

--- a/generated/messages/google/protobuf/FileDescriptorProto.ts
+++ b/generated/messages/google/protobuf/FileDescriptorProto.ts
@@ -61,7 +61,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface FileDescriptorProto {
+  export type FileDescriptorProto = {
     name?: string;
     package?: string;
     dependency: string[];
@@ -74,6 +74,7 @@ export declare namespace $.google.protobuf {
     publicDependency: number[];
     weakDependency: number[];
     syntax?: string;
+    edition?: string;
   }
 }
 export type Type = $.google.protobuf.FileDescriptorProto;
@@ -92,6 +93,7 @@ export function getDefaultValue(): $.google.protobuf.FileDescriptorProto {
     publicDependency: [],
     weakDependency: [],
     syntax: "",
+    edition: "",
   };
 }
 
@@ -116,6 +118,7 @@ export function encodeJson(value: $.google.protobuf.FileDescriptorProto): unknow
   result.publicDependency = value.publicDependency.map(value => tsValueToJsonValueFns.int32(value));
   result.weakDependency = value.weakDependency.map(value => tsValueToJsonValueFns.int32(value));
   if (value.syntax !== undefined) result.syntax = tsValueToJsonValueFns.string(value.syntax);
+  if (value.edition !== undefined) result.edition = tsValueToJsonValueFns.string(value.edition);
   return result;
 }
 
@@ -133,6 +136,7 @@ export function decodeJson(value: any): $.google.protobuf.FileDescriptorProto {
   result.publicDependency = value.publicDependency?.map((value: any) => jsonValueToTsValueFns.int32(value)) ?? [];
   result.weakDependency = value.weakDependency?.map((value: any) => jsonValueToTsValueFns.int32(value)) ?? [];
   if (value.syntax !== undefined) result.syntax = jsonValueToTsValueFns.string(value.syntax);
+  if (value.edition !== undefined) result.edition = jsonValueToTsValueFns.string(value.edition);
   return result;
 }
 
@@ -201,6 +205,12 @@ export function encodeBinary(value: $.google.protobuf.FileDescriptorProto): Uint
     const tsValue = value.syntax;
     result.push(
       [12, tsValueToWireValueFns.string(tsValue)],
+    );
+  }
+  if (value.edition !== undefined) {
+    const tsValue = value.edition;
+    result.push(
+      [13, tsValueToWireValueFns.string(tsValue)],
     );
   }
   return serialize(result);
@@ -286,6 +296,13 @@ export function decodeBinary(binary: Uint8Array): $.google.protobuf.FileDescript
     const value = wireValueToTsValueFns.string(wireValue);
     if (value === undefined) break field;
     result.syntax = value;
+  }
+  field: {
+    const wireValue = wireFields.get(13);
+    if (wireValue === undefined) break field;
+    const value = wireValueToTsValueFns.string(wireValue);
+    if (value === undefined) break field;
+    result.edition = value;
   }
   return result;
 }

--- a/generated/messages/google/protobuf/FileDescriptorSet.ts
+++ b/generated/messages/google/protobuf/FileDescriptorSet.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface FileDescriptorSet {
+  export type FileDescriptorSet = {
     file: FileDescriptorProto[];
   }
 }

--- a/generated/messages/google/protobuf/FileOptions.ts
+++ b/generated/messages/google/protobuf/FileOptions.ts
@@ -33,7 +33,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface FileOptions {
+  export type FileOptions = {
     javaPackage?: string;
     javaOuterClassname?: string;
     optimizeFor?: OptimizeMode;
@@ -42,6 +42,7 @@ export declare namespace $.google.protobuf {
     ccGenericServices?: boolean;
     javaGenericServices?: boolean;
     pyGenericServices?: boolean;
+    /** @deprecated */
     javaGenerateEqualsAndHash?: boolean;
     deprecated?: boolean;
     javaStringCheckUtf8?: boolean;

--- a/generated/messages/google/protobuf/GeneratedCodeInfo.ts
+++ b/generated/messages/google/protobuf/GeneratedCodeInfo.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface GeneratedCodeInfo {
+  export type GeneratedCodeInfo = {
     annotation: Annotation[];
   }
 }

--- a/generated/messages/google/protobuf/MessageOptions.ts
+++ b/generated/messages/google/protobuf/MessageOptions.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface MessageOptions {
+  export type MessageOptions = {
     messageSetWireFormat?: boolean;
     noStandardDescriptorAccessor?: boolean;
     deprecated?: boolean;

--- a/generated/messages/google/protobuf/MethodDescriptorProto.ts
+++ b/generated/messages/google/protobuf/MethodDescriptorProto.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface MethodDescriptorProto {
+  export type MethodDescriptorProto = {
     name?: string;
     inputType?: string;
     outputType?: string;

--- a/generated/messages/google/protobuf/MethodOptions.ts
+++ b/generated/messages/google/protobuf/MethodOptions.ts
@@ -33,7 +33,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface MethodOptions {
+  export type MethodOptions = {
     deprecated?: boolean;
     idempotencyLevel?: IdempotencyLevel;
     uninterpretedOption: UninterpretedOption[];

--- a/generated/messages/google/protobuf/OneofDescriptorProto.ts
+++ b/generated/messages/google/protobuf/OneofDescriptorProto.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface OneofDescriptorProto {
+  export type OneofDescriptorProto = {
     name?: string;
     options?: OneofOptions;
   }

--- a/generated/messages/google/protobuf/OneofOptions.ts
+++ b/generated/messages/google/protobuf/OneofOptions.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface OneofOptions {
+  export type OneofOptions = {
     uninterpretedOption: UninterpretedOption[];
   }
 }

--- a/generated/messages/google/protobuf/ServiceDescriptorProto.ts
+++ b/generated/messages/google/protobuf/ServiceDescriptorProto.ts
@@ -32,7 +32,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface ServiceDescriptorProto {
+  export type ServiceDescriptorProto = {
     name?: string;
     method: MethodDescriptorProto[];
     options?: ServiceOptions;

--- a/generated/messages/google/protobuf/ServiceOptions.ts
+++ b/generated/messages/google/protobuf/ServiceOptions.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface ServiceOptions {
+  export type ServiceOptions = {
     deprecated?: boolean;
     uninterpretedOption: UninterpretedOption[];
   }

--- a/generated/messages/google/protobuf/SourceCodeInfo.ts
+++ b/generated/messages/google/protobuf/SourceCodeInfo.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface SourceCodeInfo {
+  export type SourceCodeInfo = {
     location: Location[];
   }
 }

--- a/generated/messages/google/protobuf/UninterpretedOption.ts
+++ b/generated/messages/google/protobuf/UninterpretedOption.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf {
-  export interface UninterpretedOption {
+  export type UninterpretedOption = {
     name: NamePart[];
     identifierValue?: string;
     positiveIntValue?: string;

--- a/generated/messages/google/protobuf/compiler/(CodeGeneratorResponse)/File.ts
+++ b/generated/messages/google/protobuf/compiler/(CodeGeneratorResponse)/File.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.compiler.CodeGeneratorResponse {
-  export interface File {
+  export type File = {
     name?: string;
     insertionPoint?: string;
     content?: string;

--- a/generated/messages/google/protobuf/compiler/CodeGeneratorRequest.ts
+++ b/generated/messages/google/protobuf/compiler/CodeGeneratorRequest.ts
@@ -32,7 +32,7 @@ import {
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.compiler {
-  export interface CodeGeneratorRequest {
+  export type CodeGeneratorRequest = {
     fileToGenerate: string[];
     parameter?: string;
     compilerVersion?: Version;

--- a/generated/messages/google/protobuf/compiler/CodeGeneratorResponse.ts
+++ b/generated/messages/google/protobuf/compiler/CodeGeneratorResponse.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.compiler {
-  export interface CodeGeneratorResponse {
+  export type CodeGeneratorResponse = {
     error?: string;
     supportedFeatures?: string;
     file: File[];

--- a/generated/messages/google/protobuf/compiler/Version.ts
+++ b/generated/messages/google/protobuf/compiler/Version.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../../core/runtime/wire/deserialize.ts";
 
 export declare namespace $.google.protobuf.compiler {
-  export interface Version {
+  export type Version = {
     major?: number;
     minor?: number;
     patch?: number;


### PR DESCRIPTION
Change typegen using type alias instead of using interface.
According to [implicit index signature](https://github.com/microsoft/TypeScript/pull/7029) in TypeScript, we can easily manipulate type alias using `Type extends Record<string, unknown>`.
Manipulating type like this is especially useful when filtering some `oneof` types.