### PR TITLE
Fix group keyword parsing logic (#246)

### DIFF
--- a/core/parser/proto.regression.test.ts
+++ b/core/parser/proto.regression.test.ts
@@ -153,3 +153,12 @@ Deno.test("#172", () => {
     }
   `);
 });
+
+Deno.test("#246", () => {
+  parse(String.raw`
+    message group_info {}
+    message Foo {
+      repeated group_info bar = 1;
+    }
+  `);
+});

--- a/core/parser/proto.ts
+++ b/core/parser/proto.ts
@@ -1300,7 +1300,7 @@ function acceptGroup(
     return;
   }
   skipWsAndComments(parser);
-  const keyword = acceptKeyword(parser, "group");
+  const keyword = acceptKeyword(parser, /^group\b/);
   if (!keyword) {
     parser.loc = loc;
     return;


### PR DESCRIPTION
타입명에 group이 포함되는 경우 타입명을 `group` 키워드로 인식하는 문제가 있어 해결합니다.

resolves #246