### PR TITLE
ts(codegen): Add support for proto3 optional on getDefaultValue

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -338,7 +338,9 @@ const getGetDefaultValueCode: GetCodeFn = ({ typePath, message }) => {
     `export function getDefaultValue(): $${typePath} {\n`,
     "  return {\n",
     message.fields.map((field) => {
-      if (!field.default) return `    ${field.tsName}: undefined,\n`;
+      if (!field.default || field.schema.kind === "optional") {
+        return `    ${field.tsName}: undefined,\n`;
+      }
       return `    ${field.tsName}: ${field.default},\n`;
     }).join(""),
     message.oneofFields.map(


### PR DESCRIPTION
```proto3
syntax = "proto3";

enum A {
  DEFAULT = 0;
  SOME = 1;
  WHY = 2;
}

message B {
  optional A a = 1;
  optional int32 b = 2;
  A c = 3;
  int32 d = 4;
}
```
## As-is
```typescript
export function getDefaultValue(): $.B {
  return {
    a: undefined,
    b: undefined,
    c: "DEFAULT",
    d: 0,
  };
}
```
## To-be
```typescript
export function getDefaultValue(): $.B {
  return {
    a: "DEFAULT",
    b: 0,
    c: "DEFAULT",
    d: 0,
  };
}
```