### PR TITLE
fix(lsp/semantic-token): Cover more tokens in semantic-token-provider

### DIFF
--- a/core/ast/top-level-definitions.ts
+++ b/core/ast/top-level-definitions.ts
@@ -128,7 +128,7 @@ export interface Rpc extends StatementBase {
   keyword: Keyword;
   rpcName: Token;
   reqType: RpcType;
-  returns: Token;
+  returns: Keyword;
   resType: RpcType;
   semiOrRpcBody: Semi | RpcBody;
 }

--- a/core/parser/misc.ts
+++ b/core/parser/misc.ts
@@ -76,6 +76,15 @@ export function acceptSpecialToken<TType extends string>(
   return { type, ...token };
 }
 
+export function expectSpecialToken<TType extends string>(
+  parser: RecursiveDescentParser,
+  type: TType,
+  pattern: Pattern = identPattern,
+): Token & { type: TType } {
+  const token = parser.expect(pattern);
+  return { type, ...token };
+}
+
 export function acceptPatternAndThen<T>(
   pattern: Pattern,
   then: (token: Token) => T,

--- a/core/parser/proto.ts
+++ b/core/parser/proto.ts
@@ -4,8 +4,8 @@ import {
   acceptPatternAndThen,
   acceptSpecialToken,
   choice,
-  flipFlop,
   expectSpecialToken,
+  flipFlop,
   many,
   mergeSpans,
 } from "./misc.ts";

--- a/core/parser/proto.ts
+++ b/core/parser/proto.ts
@@ -5,6 +5,7 @@ import {
   acceptSpecialToken,
   choice,
   flipFlop,
+  expectSpecialToken,
   many,
   mergeSpans,
 } from "./misc.ts";
@@ -195,6 +196,13 @@ function acceptKeyword(
   pattern: Pattern = identPattern,
 ): ast.Keyword | undefined {
   return acceptSpecialToken(parser, "keyword", pattern);
+}
+
+function expectKeyword(
+  parser: ProtoParser,
+  pattern: Pattern = identPattern,
+): ast.Keyword {
+  return expectSpecialToken(parser, "keyword", pattern);
 }
 
 function acceptCommentGroup(
@@ -1403,7 +1411,7 @@ function acceptRpc(
   skipWsAndComments(parser);
   const reqType = expectRpcType(parser);
   skipWsAndComments(parser);
-  const returns = parser.expect("returns");
+  const returns = expectKeyword(parser, "returns");
   skipWsAndComments(parser);
   const resType = expectRpcType(parser);
   skipWsAndComments(parser);

--- a/core/visitor/index.ts
+++ b/core/visitor/index.ts
@@ -291,7 +291,7 @@ export const visitor: Visitor = {
       visitor.visitKeyword(visitor, node.keyword);
       visitor.visitToken(visitor, node.rpcName);
       visitor.visitRpcType(visitor, node.reqType);
-      visitor.visitToken(visitor, node.returns);
+      visitor.visitKeyword(visitor, node.returns);
       visitor.visitRpcType(visitor, node.resType);
       if (node.semiOrRpcBody.type === "semi") {
         visitor.visitSemi(visitor, node.semiOrRpcBody);


### PR DESCRIPTION
- Change node type of `returns` in Rpc AST to `Keyword`
- Refactor semantic-token-provider and add rpc, scalar type, public/weak import support.

This fix resolves https://github.com/pbkit/vscode-pbkit/issues/22