### PR TITLE
Added support for v1beta1 module files (buf.yaml)

### DIFF
--- a/compat/buf/module.ts
+++ b/compat/buf/module.ts
@@ -1,0 +1,26 @@
+import { parse as parseYaml } from "https://deno.land/std@0.175.0/encoding/yaml.ts";
+
+export interface BufModule {
+  version: string;
+  build: {}
+}
+
+export interface BufModuleV1Beta1 extends BufModule {
+  version: "v1beta1";
+  build: {
+    roots: []
+  }
+}
+
+export interface BufModuleV1 extends BufModule {
+  version: "v1";
+}
+
+export function parseBufModuleYaml(text: string): BufModuleV1 | BufModuleV1Beta1 {
+  const yaml = parseYaml(text) as any;
+  const result = { version: String(yaml.version || "v1"), build: {} } as BufModuleV1 | BufModuleV1Beta1;
+  if (result.version === "v1beta1") {
+    result.build.roots = yaml.build && Array.isArray(yaml.build.roots) ? yaml.build.roots : [];
+  }
+  return result;
+}

--- a/language-server/project.ts
+++ b/language-server/project.ts
@@ -3,6 +3,7 @@ import { getVendorDir } from "../cli/pb/config.ts";
 import expandEntryPaths from "../cli/pb/cmds/gen/expandEntryPaths.ts";
 import { loadPollapoYml } from "../cli/pollapo/pollapoYml.ts";
 import { parseBufWorkYaml } from "../compat/buf/workspace.ts";
+import { parseBufModuleYaml } from "../compat/buf/module.ts";
 import { Loader } from "../core/loader/index.ts";
 import combineLoader from "../core/loader/combineLoader.ts";
 import memoizeLoader, { MemoizedLoader } from "../core/loader/memoizeLoader.ts";
@@ -109,6 +110,25 @@ async function getBufWorkDirs(
     return bufWorkYaml.directories.map(
       (directory) => resolve(projectPath, String(directory)),
     );
+  } catch {
+    return await getBufModuleV1Beta1BuildRoots(projectPath);
+  }
+  return [];
+}
+
+async function getBufModuleV1Beta1BuildRoots(
+  projectPath: string,
+): Promise<string[]> {
+  try {
+    const bufModuleYamlPath = resolve(projectPath, "buf.yaml");
+    const bufModuleYaml = parseBufModuleYaml(
+      await Deno.readTextFile(fromFileUrl(bufModuleYamlPath)),
+    );
+    if (bufModuleYaml.version === "v1beta1") {
+      return bufModuleYaml.build.roots.map(
+        (directory) => resolve(projectPath, String(directory)),
+      );
+    }
   } catch {}
   return [];
 }


### PR DESCRIPTION
Added logic to look for build directories in a `v1beta1` versioned `buf.yaml` files if loading it from a `buf.work.yaml` fails.