### PR TITLE
add a function for fetching commit hash with '--git' option

### DIFF
--- a/cli/pollapo/cmds/install.ts
+++ b/cli/pollapo/cmds/install.ts
@@ -27,6 +27,7 @@ import {
   cacheDeps,
   depToString,
   downloadZipAndYmlWithGit,
+  fetchCommitHashWithGit,
   getDownloadZipAndYmlFnByToken,
   getFetchCommitHash,
   getZipPath,
@@ -76,7 +77,7 @@ export default new Command()
         cacheDir,
         clean: !!options.clean,
         pollapoYml,
-        fetchCommitHash: getFetchCommitHash(token),
+        fetchCommitHash: options.git ? fetchCommitHashWithGit : getFetchCommitHash(token),
         downloadZipAndYml: options.git
           ? downloadZipAndYmlWithGit
           : getDownloadZipAndYmlFnByToken(token),

--- a/cli/pollapo/cmds/install.ts
+++ b/cli/pollapo/cmds/install.ts
@@ -77,7 +77,9 @@ export default new Command()
         cacheDir,
         clean: !!options.clean,
         pollapoYml,
-        fetchCommitHash: options.git ? fetchCommitHashWithGit : getFetchCommitHash(token),
+        fetchCommitHash: options.git
+          ? fetchCommitHashWithGit
+          : getFetchCommitHash(token),
         downloadZipAndYml: options.git
           ? downloadZipAndYmlWithGit
           : getDownloadZipAndYmlFnByToken(token),

--- a/cli/pollapo/pollapoYml.ts
+++ b/cli/pollapo/pollapoYml.ts
@@ -330,12 +330,12 @@ function sortObjectKeys(obj: Record<string, any>): Record<string, any> {
 export const fetchCommitHashWithGit = async (
   { user, repo, rev }: PollapoDep,
 ): Promise<string> => {
-  const repoUrl = `git@github.com:${user}/${repo}.git`;
   const git = await which("git");
   if (!git) throw new Error("git not found");
+  const repoUrl = `git@github.com:${user}/${repo}.git`;
   const match = new TextDecoder().decode(
     await Deno.run({
-      cmd: ["git", "ls-remote", "--heads", "--tags", repoUrl],
+      cmd: [git, "ls-remote", "--heads", "--tags", repoUrl],
       stdout: "piped",
     }).output(),
   ).trim().match(
@@ -359,9 +359,9 @@ export const downloadZipAndYmlWithGit: DownloadZipAndYmlFn = async (
   zipPath,
   ymlPath,
 ) => {
-  const repoUrl = `git@github.com:${user}/${repo}.git`;
   const git = await which("git");
   if (!git) throw new Error("git not found");
+  const repoUrl = `git@github.com:${user}/${repo}.git`;
   const cwd = await Deno.makeTempDir();
   await Deno.run({ cwd, cmd: [git, "init"] }).status();
   await Deno.run({ cwd, cmd: [git, "remote", "add", "origin", repoUrl] })

--- a/cli/pollapo/pollapoYml.ts
+++ b/cli/pollapo/pollapoYml.ts
@@ -327,6 +327,47 @@ function sortObjectKeys(obj: Record<string, any>): Record<string, any> {
   return result;
 }
 
+async function getCommitHashFromRemote(
+  repoUrl: string,
+  ref: string,
+): Promise<string> {
+  const process = Deno.run({
+    cmd: ["git", "ls-remote", "--heads", "--tags", repoUrl],
+    stdout: "piped",
+  });
+
+  const output = await process.output();
+  process.close();
+
+  const decoder = new TextDecoder();
+  const outputStr = decoder.decode(output).trim();
+  const regex = new RegExp(`^([0-9a-f]{40})\\s+refs/(heads|tags)/${ref}$`, "m");
+
+  const match = outputStr.match(regex);
+  if (match) {
+    return match[1];
+  }
+
+  throw new Error(
+    `Could not find commit hash for ref '${ref}' in the repository '${repoUrl}'`,
+  );
+}
+
+export const fetchCommitHashWithGit = async (
+  { user, repo, rev }: PollapoDep,
+): Promise<string> => {
+  const repoUrl = `git@github.com:${user}/${repo}.git`;
+  const git = await which("git");
+  if (!git) throw new Error("git not found");
+
+  const revType = getRevType(rev);
+  if (revType === "commit") {
+    return rev;
+  }
+
+  return await getCommitHashFromRemote(repoUrl, rev);
+};
+
 export function getFetchCommitHash(token?: string) {
   return async function fetchCommitHash(dep: PollapoDep): Promise<string> {
     const res = await backoff(() => fetchCommitStatus({ token, ...dep }));


### PR DESCRIPTION
Added "fetchCommitHashWithGit" to fetch commit hashes from remote repositories.
When the --git option is used, it directly executes git commands for this purpose.